### PR TITLE
Jellybean wifi fix 1/3

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -69,8 +69,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/recovery/postrecoveryboot.sh:recovery/system/bin/postrecoveryboot.sh
 
 #NVRAM setup
-PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/prebuilt/system/vendor/firmware/nvram_net.txt:system/vendor/firmware/nvram_net.txt
+#PRODUCT_COPY_FILES += \
+#    $(LOCAL_PATH)/prebuilt/system/vendor/firmware/nvram_net.txt:system/vendor/firmware/nvram_net.txt
 
 # Permissions
 PRODUCT_COPY_FILES += \

--- a/prebuilt/system/etc/vold.fstab
+++ b/prebuilt/system/etc/vold.fstab
@@ -28,5 +28,5 @@
 #<-- p11171 dongseok modified
 #dev_mount sdcard /mnt/sdcard auto /devices/platform/msm_sdcc.3/mmc_host /devices/platform/msm_sdcc.1/mmc_host
 dev_mount sdcard /mnt/sdcard 27 /devices/platform/msm_sdcc.1/mmc_host
-dev_mount sdcard /mnt/sdcard/external_sd auto /devices/platform/msm_sdcc.3/mmc_host
+#dev_mount sdcard /mnt/sdcard/external_sd auto /devices/platform/msm_sdcc.3/mmc_host
 #-->

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -169,11 +169,11 @@ lib/libril-qcril-hook-oem.so
 
 # wifi
 #etc/wifi/wpa_supplicant.conf
-#etc/wl/bcm43291_apsta.bin
-#etc/wl/bcm43291_mfg.bin
-#etc/wl/bcm43291_p2p.bin
-#etc/wl/bcm43291.bin
-#etc/wl/nvram.txt
+etc/wl/bcm43291_apsta.bin
+etc/wl/bcm43291_mfg.bin
+etc/wl/bcm43291_p2p.bin
+etc/wl/bcm43291.bin
+etc/wl/nvram.txt
 #lib/libhardware_legacy.so
 
 # Yamaha

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -378,9 +378,9 @@ service amp_unload /system/bin/amploader -u
     oneshot
 
 #service wpa_supplicant /system/bin/wpa_supplicant -Dwext -iwlan0 -c /data/misc/wifi/wpa_supplicant.conf
-service wpa_supplicant /system/bin/wpa_supplicant -Dwext -iwlan0 -c /system/etc/wifi/wpa_supplicant.conf
-    user root
-    group wifi inet
+service wpa_supplicant /system/bin/wpa_supplicant -dddt -Dwext -iwlan0 -c/system/etc/wifi/wpa_supplicant.conf
+#    user root
+    group system wifi inet
 #    socket wpa_wlan0 dgram 660 wifi wifi
     disabled
     oneshot
@@ -505,11 +505,11 @@ service qcom-post-boot /system/bin/sh /system/etc/init.qcom.post_boot.sh
     disabled
     oneshot
 
-#service wifi-sdio-on /system/bin/sh /system/etc/init.qcom.sdio.sh
-#    class late_start
-#    group wifi inet
-#    disabled
-#    oneshot
+service wifi-sdio-on /system/bin/sh /system/etc/init.qcom.sdio.sh
+    class late_start
+    group wifi inet
+    disabled
+    oneshot
 
 service wifi-crda /system/bin/sh /system/etc/init.crda.sh
    class late_start

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -377,28 +377,11 @@ service amp_unload /system/bin/amploader -u
     disabled
     oneshot
 
-service p2p_supplicant /system/bin/logwrapper /system/bin/wpa_supplicant \
-    -ip2p0 -Dnl80211 -c/data/misc/wifi/p2p_supplicant.conf -N \
-    -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf -dddd \
-    -e/data/misc/wifi/entropy.bin -puse_p2p_group_interface=1
-    #   we will start as root and wpa_supplicant will switch to user wifi
-    #   after setting up the capabilities required for WEXT
-    #   user wifi
-    #   group wifi inet keystore
-    class main
-    socket wpa_wlan0 dgram 660 wifi wifi
-    disabled
-    oneshot
-
-service wpa_supplicant /system/bin/logwrapper /system/bin/wpa_supplicant \
-    -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf -dddd \
-    -e/data/misc/wifi/entropy.bin
-    #   we will start as root and wpa_supplicant will switch to user wifi
-    #   after setting up the capabilities required for WEXT
-    #   user wifi
-    #   group wifi inet keystore
-    class main
-    socket wpa_wlan0 dgram 660 wifi wifi
+#service wpa_supplicant /system/bin/wpa_supplicant -Dwext -iwlan0 -c /data/misc/wifi/wpa_supplicant.conf
+service wpa_supplicant /system/bin/wpa_supplicant -Dwext -iwlan0 -c /system/etc/wifi/wpa_supplicant.conf
+    user root
+    group wifi inet
+#    socket wpa_wlan0 dgram 660 wifi wifi
     disabled
     oneshot
 
@@ -522,11 +505,11 @@ service qcom-post-boot /system/bin/sh /system/etc/init.qcom.post_boot.sh
     disabled
     oneshot
 
-service wifi-sdio-on /system/bin/sh /system/etc/init.qcom.sdio.sh
-    class late_start
-    group wifi inet
-    disabled
-    oneshot
+#service wifi-sdio-on /system/bin/sh /system/etc/init.qcom.sdio.sh
+#    class late_start
+#    group wifi inet
+#    disabled
+#    oneshot
 
 service wifi-crda /system/bin/sh /system/etc/init.crda.sh
    class late_start

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -154,7 +154,7 @@ on post-fs-data
     # Create the directories used by the Wireless subsystem
     mkdir /data/misc/wifi 0770 wifi wifi
     mkdir /data/misc/wifi/sockets 0770 wifi wifi
-    mkdir /data/misc/wifi/wpa_supplicant 0770 wifi wifi
+#    mkdir /data/misc/wifi/wpa_supplicant 0770 wifi wifi
     mkdir /data/misc/dhcp 0770 dhcp dhcp
     chown dhcp dhcp /data/misc/dhcp
 
@@ -178,7 +178,7 @@ on post-fs-data
 
     #Create the symlink to qcn wpa_supplicant folder for ar6000 wpa_supplicant
     mkdir /data/system 0775 system system
-    symlink /data/misc/wifi/wpa_supplicant /data/system/wpa_supplicant
+#    symlink /data/misc/wifi/wpa_supplicant /data/system/wpa_supplicant
 
     #Create directories for wiper services
     mkdir /data/wpstiles/ 0755 shell
@@ -377,11 +377,15 @@ service amp_unload /system/bin/amploader -u
     disabled
     oneshot
 
-#service wpa_supplicant /system/bin/wpa_supplicant -Dwext -iwlan0 -c /data/misc/wifi/wpa_supplicant.conf
-service wpa_supplicant /system/bin/wpa_supplicant -dddt -Dwext -iwlan0 -c/system/etc/wifi/wpa_supplicant.conf
-#    user root
+service p2p_supplicant /system/bin/logwrapper /system/bin/wpa_supplicant -dd -Dwext -iwlan0 -c /data/misc/wifi/wpa_supplicant.conf
+    socket wpa_wlan0 dgram 0660 wifi wifi
     group system wifi inet
-#    socket wpa_wlan0 dgram 660 wifi wifi
+    disabled
+    oneshot
+
+service wpa_supplicant /system/bin/logwrapper /system/bin/wpa_supplicant -dd -Dwext -iwlan0 -c /data/misc/wifi/wpa_supplicant.conf
+    socket wpa_wlan0 dgram 660 wifi wifi
+    group system wifi inet
     disabled
     oneshot
 

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -77,11 +77,11 @@ on post-fs-data
    start modem_link
 
 on boot
-   start qcamerasvr
-service qcamerasvr /system/bin/mm-qcamera-daemon
-    class late_start
-    user camera
-    group camera system inet input
+#   start qcamerasvr
+#service qcamerasvr /system/bin/mm-qcamera-daemon
+#    class late_start
+#    user camera
+#    group camera system inet input
 
 service kickstart /system/bin/qcks l
     oneshot

--- a/wifi.mk
+++ b/wifi.mk
@@ -1,17 +1,17 @@
 # Wifi related defines
-BOARD_HOSTAPD_DRIVER                := WEXT
-BOARD_HOSTAPD_PRIVATE_LIB           := lib_driver_cmd_wext
+#BOARD_HOSTAPD_DRIVER                := WEXT
+#BOARD_HOSTAPD_PRIVATE_LIB           := lib_driver_cmd_wext
 BOARD_WLAN_DEVICE                   := bcm4329
 #BOARD_WLAN_DEVICE_REV               := bcm4329
 BOARD_WPA_SUPPLICANT_DRIVER         := WEXT
 BOARD_WPA_SUPPLICANT_PRIVATE_LIB    := lib_driver_cmd_wext
 WIFI_BAND                           := 802_11_ABG
-WIFI_DRIVER_FW_PATH_AP              := "/vendor/firmware/fw_bcm4329_apsta.bin"
-WIFI_DRIVER_FW_PATH_PARAM           := "/sys/module/bcm4329/parameters/firmware_path"
-WIFI_DRIVER_FW_PATH_STA             := "/vendor/firmware/fw_bcm4329.bin"
-WIFI_DRIVER_MODULE_ARG              := "firmware_path=/vendor/firmware/fw_bcm4329.bin nvram_path=/vendor/firmware/nvram_net.txt iface_name=wlan"
+WIFI_DRIVER_FW_PATH_AP              := "/system/vendor/firmware/bcm43291_apsta.bin"
+WIFI_DRIVER_FW_PATH_PARAM           := "/sys/module/wlan/parameters/firmware_path"
+WIFI_DRIVER_FW_PATH_STA             := "/system/vendor/firmware/bcm43291.bin"
+WIFI_DRIVER_MODULE_ARG              := "firmware_path=/system/vendor/firmware/bcm43291.bin nvram_path=/system/vendor/firmware/nvram.txt"
 WIFI_DRIVER_MODULE_NAME             := "wlan"
 WIFI_DRIVER_MODULE_PATH             := "/system/lib/modules/wlan.ko"
 WPA_SUPPLICANT_VERSION              := VER_0_8_X
-#WIFI_EXT_MODULE_PATH        	    := "/system/lib/modules/librasdioif.ko"
-#WIFI_EXT_MODULE_NAME        	    := "librasdioif"
+WIFI_EXT_MODULE_PATH                := "/system/lib/modules/librasdioif.ko"
+WIFI_EXT_MODULE_NAME                := "librasdioif"

--- a/wifi.mk
+++ b/wifi.mk
@@ -2,7 +2,7 @@
 BOARD_HOSTAPD_DRIVER                := WEXT
 BOARD_HOSTAPD_PRIVATE_LIB           := lib_driver_cmd_wext
 BOARD_WLAN_DEVICE                   := bcm4329
-BOARD_WLAN_DEVICE_REV               := bcm4329
+#BOARD_WLAN_DEVICE_REV               := bcm4329
 BOARD_WPA_SUPPLICANT_DRIVER         := WEXT
 BOARD_WPA_SUPPLICANT_PRIVATE_LIB    := lib_driver_cmd_wext
 WIFI_BAND                           := 802_11_ABG
@@ -10,6 +10,8 @@ WIFI_DRIVER_FW_PATH_AP              := "/vendor/firmware/fw_bcm4329_apsta.bin"
 WIFI_DRIVER_FW_PATH_PARAM           := "/sys/module/bcm4329/parameters/firmware_path"
 WIFI_DRIVER_FW_PATH_STA             := "/vendor/firmware/fw_bcm4329.bin"
 WIFI_DRIVER_MODULE_ARG              := "firmware_path=/vendor/firmware/fw_bcm4329.bin nvram_path=/vendor/firmware/nvram_net.txt iface_name=wlan"
-WIFI_DRIVER_MODULE_NAME             := "bcm4329"
-WIFI_DRIVER_MODULE_PATH             := "/system/modules/bcm4329.ko"
+WIFI_DRIVER_MODULE_NAME             := "wlan"
+WIFI_DRIVER_MODULE_PATH             := "/system/lib/modules/wlan.ko"
 WPA_SUPPLICANT_VERSION              := VER_0_8_X
+#WIFI_EXT_MODULE_PATH        	    := "/system/lib/modules/librasdioif.ko"
+#WIFI_EXT_MODULE_NAME        	    := "librasdioif"

--- a/wifi.mk
+++ b/wifi.mk
@@ -6,10 +6,10 @@ BOARD_WLAN_DEVICE                   := bcm4329
 BOARD_WPA_SUPPLICANT_DRIVER         := WEXT
 BOARD_WPA_SUPPLICANT_PRIVATE_LIB    := lib_driver_cmd_wext
 WIFI_BAND                           := 802_11_ABG
-WIFI_DRIVER_FW_PATH_AP              := "/system/vendor/firmware/bcm43291_apsta.bin"
+WIFI_DRIVER_FW_PATH_AP              := "/system/etc/wl/bcm43291_apsta.bin"
 WIFI_DRIVER_FW_PATH_PARAM           := "/sys/module/wlan/parameters/firmware_path"
-WIFI_DRIVER_FW_PATH_STA             := "/system/vendor/firmware/bcm43291.bin"
-WIFI_DRIVER_MODULE_ARG              := "firmware_path=/system/vendor/firmware/bcm43291.bin nvram_path=/system/vendor/firmware/nvram.txt"
+WIFI_DRIVER_FW_PATH_STA             := "/system/etc/wl/bcm43291.bin"
+WIFI_DRIVER_MODULE_ARG              := "firmware_path=/system/etc/wl/bcm43291.bin nvram_path=/system/etc/wl/nvram.txt"
 WIFI_DRIVER_MODULE_NAME             := "wlan"
 WIFI_DRIVER_MODULE_PATH             := "/system/lib/modules/wlan.ko"
 WPA_SUPPLICANT_VERSION              := VER_0_8_X


### PR DESCRIPTION
commented hostapd in wifi.mk because it brake netd
modifed supplicants service to use android private socket and disabled strings for unix socket
disabled qcamerasrv it make noise in logcat
