### PR TITLE
fix conflicting browser plugins

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -88,16 +88,8 @@ lib/libchromatix_imx074_default_video.so
 lib/libchromatix_imx074_preview.so
 lib/libchromatix_imx074_zsl.so
 
-# Chromium plug-ins
-lib/libcneapiclient.so
-lib/libcneqmiutils.so
+# Diag
 lib/libdiag.so
-lib/libdnshostprio.so
-lib/libnetmonitor.so
-lib/libtcpfinaggr.so
-lib/pp_proc_plugin.so
-lib/qnet-plugin.so
-lib/tcp-connections.so
 
 ## CPU management
 #bin/mpdecision

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -49,6 +49,7 @@ on early-init
 
 
 on boot
+    mount debugfs /sys/kernel/debug /sys/kernel/debug
     chown bluetooth bluetooth /sys/module/bluetooth_power/parameters/power
     chown bluetooth bluetooth /sys/class/rfkill/rfkill0/type
     chown bluetooth bluetooth /sys/class/rfkill/rfkill0/state


### PR DESCRIPTION
Removed files causing browser crashes.  Add additional line to init.qcom.rc to fix kernel debug errors.
